### PR TITLE
Fix cursor position

### DIFF
--- a/neovim-editor.html
+++ b/neovim-editor.html
@@ -2,6 +2,7 @@
   <template>
     <style>
       :host {
+        position: relative;
         min-width: 0px;
         min-height: 0px;
       }


### PR DESCRIPTION
The cursor has `position: absolute`; if there are other elements than `<neovim-component>` on the window, it still appears relative to window origin. (where it should be relative to :host's origin)

By definition absolutely positioned elements are placed relative to the first non-`initial`ly positioned parent.