### PR TITLE
allow input methods to send "<"

### DIFF
--- a/src/neovim/input.ts
+++ b/src/neovim/input.ts
@@ -299,6 +299,7 @@ export default class NeovimInput {
             return;
         }
 
-        this.inputToNeovim(t.value, event);
+        let input = t.value.replace(/</g, "<LT>");
+        this.inputToNeovim(input, event);
     }
 }


### PR DESCRIPTION
when sending text input to neovim, there is this special case to handle. Compare the ime event handler in python-client:
```
    def _gtk_input(self, widget, input_str, *args):
        self._bridge.input(input_str.replace('<', '<lt>'))
```
