### PR TITLE
Add workaround for Ctrl+Space, for which chrome assigns "Unidentified"

### DIFF
--- a/src/neovim/input.ts
+++ b/src/neovim/input.ts
@@ -137,7 +137,12 @@ export default class NeovimInput {
             case 'Insert':       return 'Insert';
             case 'Delete':       return 'Del';
             case 'Help':         return 'Help';
-            case 'Unidentified': return null;
+            case 'Unidentified': {
+                if (ctrl && key_code === 32) {
+                    return 'Space';
+                }
+                return null;
+            };
             default:             return null;
         }
     }


### PR DESCRIPTION
At least on Linux, this enables me to map <C-Space>.