### PR TITLE
Fix scroll wheel

### DIFF
--- a/src/neovim/screen-wheel.ts
+++ b/src/neovim/screen-wheel.ts
@@ -47,7 +47,6 @@ export default class ScreenWheel {
 
         this.line = Math.floor(e.y / this.store.font_attr.height);
         this.col  = Math.floor(e.x / this.store.font_attr.width);
-        let pos = e as any;
 
         const input = this.getInput(scroll_x, scroll_y);
         log.debug(`Scroll (${scroll_x}, ${scroll_y})`);

--- a/src/neovim/screen-wheel.ts
+++ b/src/neovim/screen-wheel.ts
@@ -82,7 +82,7 @@ export default class ScreenWheel {
             seq += 'S-';
         }
         seq += `ScrollWheel${this.getDirection(scroll_x, scroll_y)}>`;
-        seq += `<${this.col},${this.line}>`; // This is really needed?
+        seq += `<${this.col},${this.line}>`;
         return seq;
     }
 }

--- a/src/neovim/screen-wheel.ts
+++ b/src/neovim/screen-wheel.ts
@@ -17,6 +17,8 @@ import log from '../log';
 export default class ScreenWheel {
     x: number;
     y: number;
+    line: number;
+    col: number;
     shift: boolean;
     ctrl: boolean;
 
@@ -42,6 +44,10 @@ export default class ScreenWheel {
             // Note: At least 3 lines or 6 columns are needed to scroll screen
             return '';
         }
+
+        this.line = Math.floor(e.y / this.store.font_attr.height);
+        this.col  = Math.floor(e.x / this.store.font_attr.width);
+        let pos = e as any;
 
         const input = this.getInput(scroll_x, scroll_y);
         log.debug(`Scroll (${scroll_x}, ${scroll_y})`);
@@ -77,7 +83,7 @@ export default class ScreenWheel {
             seq += 'S-';
         }
         seq += `ScrollWheel${this.getDirection(scroll_x, scroll_y)}>`;
-        seq += `<${scroll_x},${scroll_y}>`; // This is really needed?
+        seq += `<${this.col},${this.line}>`; // This is really needed?
         return seq;
     }
 }


### PR DESCRIPTION
Hello :)

Yes, the `<ScrollWheel*><x,y>` is needed and it means  `<ScrollWheel*><col,line>`, otherwise scrolling with the mouse over a different window scrolls the window at line `scroll_y` and column `scroll_x`. (Given that it mostly produces numbers ∈ `[-3, 3]`, the 1st window gets scrolled instead of the :hovered window).

(Actually, exactly the same you did in https://github.com/rhysd/neovim-component/blob/master/src/neovim/screen-drag.ts#L22)