### PR TITLE
Disable 'alpha' on context of cursor/screen to enable sub-pixel antialiasing

### DIFF
--- a/src/neovim/cursor.ts
+++ b/src/neovim/cursor.ts
@@ -73,7 +73,7 @@ export default class NeovimCursor {
         this.element = document.querySelector('.neovim-cursor') as HTMLCanvasElement;
         this.element.style.top = '0px';
         this.element.style.left = '0px';
-        this.ctx = this.element.getContext('2d');
+        this.ctx = this.element.getContext('2d', {alpha: false});
         this.updateSize();
         this.blink_timer.on('tick', (shown: boolean) => {
             if (shown) {

--- a/src/neovim/screen.ts
+++ b/src/neovim/screen.ts
@@ -10,7 +10,7 @@ export default class NeovimScreen {
     input: Input;
 
     constructor(private store: NeovimStore, public canvas: HTMLCanvasElement) {
-        this.ctx = this.canvas.getContext('2d');
+        this.ctx = this.canvas.getContext('2d', {alpha: false});
 
         this.store.on('put', this.drawText.bind(this));
         this.store.on('clear-all', this.clearAll.bind(this));


### PR DESCRIPTION
Now browser knows that the backdrop for drawing is always opaque, the performance of drawing of transparent content and images are improved.

Additionally, at least Webkit, browser renders text with sub-pixel anti-aliasing so that the quality of readability increase a lot.

http://blogs.adobe.com/webplatform/2014/04/01/new-canvas-features/
https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext

I confirmed by `$ npm start`

#### Without `{alpha: false}`
![normal-antialias](https://cloud.githubusercontent.com/assets/546312/18982181/04685726-871f-11e6-99bf-770f899d6603.png)


#### With `{alpha: false}`
![subpixel-antialias](https://cloud.githubusercontent.com/assets/546312/18982184/0a176482-871f-11e6-8029-febf51cbca24.png)

