### PR TITLE
Enable building even when there are errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "start": "npm run dep && npm run build && npm run example",
-    "build": "tsc --pretty -p src && browserify -o build/index.js src/out/index.js",
+    "build": "tsc --pretty -p src; browserify -o build/index.js src/out/index.js",
     "debug": "ELECTRON_ENABLE_STACK_DUMPING=true NODE_ENV=debug electron .",
     "dep": "npm install && bower install && typings install && mkdir -p build",
     "example": "electron .",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -8,7 +8,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noEmitOnError": true,
+    "noEmitOnError": false,
     "target": "es5",
     "sourceMap": true
   },


### PR DESCRIPTION
Sometimes (e.g. due to typings updates), there will appear errors in the
source which prevents the package to be built, even though it works.
To remedy this, `noEmitOnErrors` has been set to `false` and the
build script has been updated to package even when there were
TypeScript errors.