### PR TITLE
Fix IME problem

### DIFF
--- a/src/neovim/input.ts
+++ b/src/neovim/input.ts
@@ -239,8 +239,9 @@ export default class NeovimInput {
         this.ime_running = true;
     }
 
-    endComposition(_: Event) {
+    endComposition(event: CompositionEvent) {
         log.debug('end composition');
+        this.inputToNeovim(event.data, event);
         this.ime_running = false;
     }
 


### PR DESCRIPTION
### What was a problem?

Japanese IME input was not properly handled so they were dropped.

### How this PR fixes the problem?

Call input listener to reflect the result of IME composition. Electron calls key related events in following orders:

#### When starting IME inputting:

1. keydown
1. compositionstart
1. input

#### When finishing IME inputting:

1. keydown
1. input
1. compositionend

This PR fixes by triggering the very last event after `compositionend`.

### Check lists

- [x] Coding style
- [x] Confirmed
  - OS:
    - macOS 10.12.4
    - Windows 7 x64
    - Arch Linux
  - nvim:
    - version: 0.2.0

