### PR TITLE
Fix cursor shape (e.g.: cmdline_insert)

### DIFF
--- a/src/lib.d.ts
+++ b/src/lib.d.ts
@@ -10,5 +10,6 @@ interface ObjectConstructor {
 
 interface String {
     repeat(n: number): string;
+    endsWith(s: string): boolean;
 }
 

--- a/src/neovim/cursor.ts
+++ b/src/neovim/cursor.ts
@@ -159,7 +159,7 @@ export default class NeovimCursor {
 
     private redrawImpl() {
         this.delay_timer = null;
-        const cursor_width = this.store.mode === 'insert' ? (window.devicePixelRatio || 1) : this.store.font_attr.draw_width;
+        const cursor_width = this.store.mode.endsWith('insert') ? (window.devicePixelRatio || 1) : this.store.font_attr.draw_width;
         const cursor_height = this.store.font_attr.draw_height;
         const x = this.store.cursor.col * this.store.font_attr.draw_width;
         const y = this.store.cursor.line * this.store.font_attr.draw_height;


### PR DESCRIPTION
### What was a problem?

The cursor shape was weird when the class `NeovimCursor` processes `cmdline_insert` action. This is emitted when moving the cursor in command line window at the bottom.

### How this PR fixes the problem?

All the actions whose name ends with `insert` have currently vertical cursor that can be confirmed emitted at the first action. There are other cursor shapes in Neovim such as when replacing text, however, this PR does not yet deal with them.

### Check lists

- [x] Coding style
- [x] Confirmed
  - OS:
    - macOS 10.12.4
    - Windows 7 x64
    - Arch Linux
  - nvim:
    - version: 0.2.0