### PR TITLE
Generate cursor shape from mode_info_set event

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   "dependencies": {
     "flux": "^3.1.2",
     "loglevel": "^1.4.1",
-    "promised-neovim-client": "^2.0.2",
-    "react": "^15.5.4"
+    "promised-neovim-client": "^2.0.2"
   },
   "devDependencies": {
     "@types/electron": "^1.4.37",
@@ -50,7 +49,7 @@
     "browserify": "^14.3.0",
     "canvas": "^1.6.5",
     "chai": "^3.5.0",
-    "electron": "^1.6.6",
+    "electron": "~1.4",
     "jsdom": "^10.1.0",
     "mocha": "^3.3.0",
     "mocha-generators": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "flux": "^3.1.2",
     "loglevel": "^1.4.1",
-    "promised-neovim-client": "^2.0.2"
+    "promised-neovim-client": "^2.0.2",
+    "react": "^15.5.4"
   },
   "devDependencies": {
     "@types/electron": "^1.4.37",
@@ -49,7 +50,7 @@
     "browserify": "^14.3.0",
     "canvas": "^1.6.5",
     "chai": "^3.5.0",
-    "electron": "~1.4",
+    "electron": "^1.6.6",
     "jsdom": "^10.1.0",
     "mocha": "^3.3.0",
     "mocha-generators": "^2.0.0",

--- a/src/neovim/actions.ts
+++ b/src/neovim/actions.ts
@@ -11,6 +11,20 @@ export interface HighlightSet {
     underline?: boolean;
 }
 
+export type ModeInfoSet = { [key: string]: ModeInfo };
+export interface ModeInfo {
+    blinkoff?: number;
+    blinkon?: number;
+    blinkwait?: number;
+    cell_percentage?: number;
+    cursor_shape?: string;
+    hl_id?: number;
+    id_lm?: number;
+    mouse_shape: number;
+    name: string;
+    short_name: string;
+}
+
 export interface Region {
     top: number;
     left: number;
@@ -36,6 +50,7 @@ export enum Kind {
     Highlight,
     Input,
     Mode,
+    ModeInfo,
     PutText,
     Resize,
     ScrollScreen,
@@ -77,6 +92,7 @@ export interface ActionType {
     line?: number;
     line_height?: number;
     lines?: number;
+    modeInfo?: ModeInfoSet;
     mode?: string;
     region?: Region;
     text?: string[][];
@@ -143,6 +159,13 @@ export function updateSpecialColor(color: number) {
     return {
         type: Kind.UpdateSP,
         color,
+    };
+}
+
+export function modeInfo(modeInfo: ModeInfoSet) {
+    return {
+        type: Kind.ModeInfo,
+        modeInfo,
     };
 }
 

--- a/src/neovim/cursor.ts
+++ b/src/neovim/cursor.ts
@@ -74,7 +74,7 @@ export default class NeovimCursor {
         this.element.style.top = '0px';
         this.element.style.left = '0px';
         this.ctx = this.element.getContext('2d', {alpha: false});
-        this.updateFontSize();
+        this.onFontSizeUpdated();
         this.blink_timer.on('tick', (shown: boolean) => {
             if (shown) {
                 this.redraw();
@@ -99,7 +99,7 @@ export default class NeovimCursor {
 
         this.store.on('cursor', this.updateCursorPos.bind(this));
         this.store.on('update-fg', () => this.redraw());
-        this.store.on('font-size-changed', this.updateFontSize.bind(this));
+        this.store.on('font-size-changed', this.onFontSizeUpdated.bind(this));
         this.store.on('blink-cursor-started', () => this.blink_timer.start());
         this.store.on('blink-cursor-stopped', () => this.blink_timer.stop());
         this.store.on('busy', () => {
@@ -117,7 +117,7 @@ export default class NeovimCursor {
         this.store.on('mode', () => this.updateCursorBlinking(this.store.mode !== 'insert'));
     }
 
-    updateFontSize() {
+    onFontSizeUpdated() {
         const f = this.store.font_attr;
         this.element.style.width = f.width + 'px';
         this.element.style.height = f.height + 'px';

--- a/src/neovim/cursor.ts
+++ b/src/neovim/cursor.ts
@@ -74,7 +74,7 @@ export default class NeovimCursor {
         this.element.style.top = '0px';
         this.element.style.left = '0px';
         this.ctx = this.element.getContext('2d', {alpha: false});
-        this.updateSize();
+        this.updateFontSize();
         this.blink_timer.on('tick', (shown: boolean) => {
             if (shown) {
                 this.redraw();
@@ -99,7 +99,7 @@ export default class NeovimCursor {
 
         this.store.on('cursor', this.updateCursorPos.bind(this));
         this.store.on('update-fg', () => this.redraw());
-        this.store.on('font-size-changed', this.updateSize.bind(this));
+        this.store.on('font-size-changed', this.updateFontSize.bind(this));
         this.store.on('blink-cursor-started', () => this.blink_timer.start());
         this.store.on('blink-cursor-stopped', () => this.blink_timer.stop());
         this.store.on('busy', () => {
@@ -117,7 +117,7 @@ export default class NeovimCursor {
         this.store.on('mode', () => this.updateCursorBlinking(this.store.mode !== 'insert'));
     }
 
-    updateSize() {
+    updateFontSize() {
         const f = this.store.font_attr;
         this.element.style.width = f.width + 'px';
         this.element.style.height = f.height + 'px';
@@ -157,17 +157,51 @@ export default class NeovimCursor {
         this.blink_timer.reset();
     }
 
+    updateCursorSize() {
+        const info = this.store.modeInfo[this.store.mode];
+        if (!info) {
+            return;
+        }
+        const {cursor_shape, cell_percentage} = info;
+        if (!cursor_shape) {
+            return;
+        }
+        const {width, height} = this.store.font_attr;
+        switch (cursor_shape) {
+            case 'horizontal': {
+                const top = height * (1 - cell_percentage / 100);
+                const right = width;
+                const bottom = height;
+                const left = 0;
+                this.element.style.clip = `rect(${top}px ${right}px ${bottom}px ${left}px)`;
+                break;
+            }
+            case 'vertical': {
+                const top = 0;
+                const right = width * (cell_percentage / 100);
+                const bottom = height;
+                const left = 0;
+                this.element.style.clip = `rect(${top}px ${right}px ${bottom}px ${left}px)`;
+                break;
+            }
+            default: {
+                this.element.style.clip = 'auto';
+                break;
+            }
+        }
+    }
+
     private redrawImpl() {
         this.delay_timer = null;
-        const cursor_width = this.store.mode.endsWith('insert') ? (window.devicePixelRatio || 1) : this.store.font_attr.draw_width;
-        const cursor_height = this.store.font_attr.draw_height;
-        const x = this.store.cursor.col * this.store.font_attr.draw_width;
-        const y = this.store.cursor.line * this.store.font_attr.draw_height;
-        const captured = this.screen_ctx.getImageData(x, y, cursor_width, cursor_height);
+        const {draw_width, draw_height} = this.store.font_attr;
+        const x = this.store.cursor.col * draw_width;
+        const y = this.store.cursor.line * draw_height;
+        const captured = this.screen_ctx.getImageData(x, y, draw_width, draw_height);
         this.ctx.putImageData(invertColor(captured), 0, 0);
     }
 
     private updateCursorBlinking(should_blink: boolean) {
+        this.updateCursorSize();
         if (should_blink) {
             if (this.store.blink_cursor) {
                 this.blink_timer.start();

--- a/src/neovim/process.ts
+++ b/src/neovim/process.ts
@@ -157,6 +157,21 @@ export default class NeovimProcess {
                 case 'update_sp':
                     d.dispatch(Action.updateSpecialColor(args[0] as number));
                     break;
+                case 'mode_info_set':
+                    // Note:
+                    // [{mode_info_set}, {mode_info_set}]
+                    //   -> { [mode_name]: {mode_info_set} }
+                    const modeInfo = args[1] as Action.ModeInfo[];
+
+                    d.dispatch(
+                        Action.modeInfo(
+                            modeInfo.reduce((set, info) => {
+                                set[info.name] = info;
+                                return set;
+                            }, Object.create(null)),
+                        ),
+                    );
+                    break;
                 case 'mode_change':
                     d.dispatch(Action.changeMode(args[0] as string));
                     break;

--- a/src/neovim/store.ts
+++ b/src/neovim/store.ts
@@ -1,5 +1,5 @@
 import {EventEmitter} from 'events';
-import {Kind, ActionType, Region} from './actions';
+import {Kind, ActionType, Region, ModeInfoSet} from './actions';
 import log from '../log';
 import ScreenDrag from './screen-drag';
 import ScreenWheel from './screen-wheel';
@@ -61,6 +61,7 @@ export default class NeovimStore extends EventEmitter {
     bg_color: string;
     sp_color: string;
     cursor: Cursor;
+    modeInfo: ModeInfoSet;
     mode: string;
     busy: boolean;
     mouse_enabled: boolean;
@@ -106,6 +107,7 @@ export default class NeovimStore extends EventEmitter {
             line: 0,
             col: 0,
         };
+        this.modeInfo = {};
         this.mode = 'normal';
         this.busy = false;
         this.mouse_enabled = true;
@@ -217,6 +219,11 @@ export default class NeovimStore extends EventEmitter {
                 this.sp_color = colorString(action.color, this.fg_color);
                 this.emit('update-sp-color');
                 log.debug('Special color is updated: ', this.sp_color);
+                break;
+            }
+            case Kind.ModeInfo: {
+                this.modeInfo = action.modeInfo;
+                this.emit('mode-info', this.modeInfo);
                 break;
             }
             case Kind.Mode: {


### PR DESCRIPTION
### What was a problem?

Related to #42, which did not properly handle all of the cursor shapes.

### How this PR fixes the problem?

This PR handles `mode_info_set` event which includes the detail relationships between the mode and cursor shape. The component will generally detect the correct cursor shape and apply it. All cursor shapes that can be seen are currently supported (see below).

- horizontal `_`
  - used in `cmdline_replace`, `replace`
- vertical `|`
  - used in `cmdline_insert`, `insert`
- block `▮`
  - used in `cmdline_normal` `normal`

The newly added method `updateCursorSize` is called every time the mode is changed and clips the cursor. The cursor shape is no longer processed by `redrawImpl` because of complexity.

I did not see any rendering issues with electron@^1.6 so the package has been updated. If you still found it buggy, please discard the commit or let me know what is/are exactly broken.

### Check lists

- [x] Coding style
- [x] Confirmed
  - OS:
    - macOS 10.12.4
    - Windows 7 x64
    - Arch Linux
  - nvim:
    - version: 0.2.0