### PR TITLE
Change destination dir of build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 /bower_components
 node_modules
-/src/**/*.js
-/src/**/*.js.map
-/test/e2e/**/*.js
-/test/e2e/**/*.js.map
 /build
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   },
   "scripts": {
     "start": "npm run dep && npm run build && npm run example",
-    "build": "tsc --pretty --project . && browserify -o build/index.js src/index.js",
+    "build": "tsc --pretty --project . && browserify -o build/index.js build/src/index.js",
     "debug": "ELECTRON_ENABLE_STACK_DUMPING=true NODE_ENV=debug electron .",
     "dep": "npm install && bower install && mkdir -p build",
     "example": "electron .",
     "lint": "tslint --type-check --project .",
     "watch": "guard --watchdir src test",
     "test": "mocha test/unit/",
-    "e2e": "mocha test/e2e/"
+    "e2e": "mocha build/test/e2e/ --opts test/e2e/mocha.opts"
   },
   "keywords": [
     "neovim",

--- a/test/e2e/smoke.ts
+++ b/test/e2e/smoke.ts
@@ -10,7 +10,7 @@ describe('neovim element', function () {
     before(function () {
         this.app = new Application({
             path: electron,
-            args: [path.join(__dirname, '..', '..')],
+            args: [path.join(__dirname, '..', '..', '..')],
             env: {
                 NODE_ENV: 'production',
             },

--- a/test/unit/cursor_test.js
+++ b/test/unit/cursor_test.js
@@ -1,9 +1,9 @@
 global.require = require;
 const assert = require('chai').assert;
 const jsdom = require('jsdom');
-const NeovimStore = require('../../src/neovim/store').default;
-const Cursor = require('../../src/neovim/cursor').default;
-const A = require('../../src/neovim/actions');
+const NeovimStore = require('../../build/src/neovim/store').default;
+const Cursor = require('../../build/src/neovim/cursor').default;
+const A = require('../../build/src/neovim/actions');
 
 describe('Cursor', () => {
     beforeEach(() => {

--- a/test/unit/input_test.js
+++ b/test/unit/input_test.js
@@ -1,8 +1,8 @@
 global.require = require;
 const assert = require('chai').assert;
 const jsdom = require('jsdom');
-const NeovimStore = require('../../src/neovim/store').default;
-const NeovimInput = require('../../src/neovim/input').default;
+const NeovimStore = require('../../build/src/neovim/store').default;
+const NeovimInput = require('../../build/src/neovim/input').default;
 
 (function(){
 var window;

--- a/test/unit/screen-drag_test.js
+++ b/test/unit/screen-drag_test.js
@@ -2,8 +2,8 @@ global.require = require;
 const assert = require('chai').assert;
 const jsdom = require('jsdom');
 const document = new jsdom.JSDOM().window.document;
-const ScreenDrag = require('../../src/neovim/screen-drag').default;
-const NeovimStore = require('../../src/neovim/store').default;
+const ScreenDrag = require('../../build/src/neovim/screen-drag').default;
+const NeovimStore = require('../../build/src/neovim/store').default;
 
 function eventFactory(kind) {
     return function (opts) {

--- a/test/unit/screen-wheel_test.js
+++ b/test/unit/screen-wheel_test.js
@@ -2,8 +2,8 @@ global.require = require;
 const assert = require('chai').assert;
 const jsdom = require('jsdom');
 const document = new jsdom.JSDOM().window.document;
-const ScreenWheel = require('../../src/neovim/screen-wheel').default;
-const NeovimStore = require('../../src/neovim/store').default;
+const ScreenWheel = require('../../build/src/neovim/screen-wheel').default;
+const NeovimStore = require('../../build/src/neovim/store').default;
 
 
 function wheelEvent(x, y, opts) {

--- a/test/unit/store_test.js
+++ b/test/unit/store_test.js
@@ -2,9 +2,9 @@ global.require = require;
 global.window = global;
 const assert = require('chai').assert;
 const jsdom = require('jsdom');
-const A = require('../../src/neovim/actions');
-const NeovimStore = require('../../src/neovim/store').default;
-const ScreenWheel = require('../../src/neovim/screen-wheel').default;
+const A = require('../../build/src/neovim/actions');
+const NeovimStore = require('../../build/src/neovim/store').default;
+const ScreenWheel = require('../../build/src/neovim/screen-wheel').default;
 const document = new jsdom.JSDOM().window.document;
 
 describe('NeovimStore', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noEmitOnError": true,
+    "outDir": "build",
     "target": "es2015",
     "sourceMap": true
   },


### PR DESCRIPTION
Change destination dir of *.js and *.js.map built by tsc to /build, because it is confusing that .js is created in /src.